### PR TITLE
fix: renderTags returning invalid htmls

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,11 +131,9 @@ export function renderTags(tags: Array<TagDescription>) {
   return tags
     .map(tag => {
       const keys = Object.keys(tag.props);
-      return `<${tag.tag} data-sm=""${keys.map(k =>
-        k === "children" ? "" : ` ${k}="${tag.props[k]}"`
-      )}>${tag.props.children || ""}</${tag.tag}>`;
-    })
-    .join("");
+      const props = keys.map(k => k === "children" ? "" : ` ${k}="${tag.props[k]}"`).join("");
+      return tag.props.children ? `<${tag.tag} data-sm=""${props}>${tag.props.children}</${tag.tag}>` : `<${tag.tag} data-sm=""${props}/>`
+    }).join("");
 }
 
 export const Title: Component<JSX.HTMLAttributes<HTMLTitleElement>> = props =>


### PR DESCRIPTION
- Not joining attributes, returning into an `Array.toString()` call which basically returns `() => join(",")`
- Not checking to see if elements have children, resulting in empty elements.

Before:
`<title data-sm=""> Sample Title </title><meta data-sm="" name="keywords", content="sample, title"></meta>`

After
`<title data-sm=""> Sample Title </title><meta data-sm="" name="keywords" content="sample, title" />`