### PR TITLE
Fix commas in SSR with multiple text children

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -131,9 +131,16 @@ export function renderTags(tags: Array<TagDescription>) {
   return tags
     .map(tag => {
       const keys = Object.keys(tag.props);
-      const props = keys.map(k => k === "children" ? "" : ` ${k}="${tag.props[k]}"`).join("");
-      return tag.props.children ? `<${tag.tag} data-sm=""${props}>${tag.props.children}</${tag.tag}>` : `<${tag.tag} data-sm=""${props}/>`
-    }).join("");
+      const props = keys.map(k => (k === "children" ? "" : ` ${k}="${tag.props[k]}"`)).join("");
+      return tag.props.children
+        ? `<${tag.tag} data-sm=""${props}>${
+            // Tags might contain multiple text children:
+            //   <Title>example - {myCompany}</Title>
+            Array.isArray(tag.props.children) ? tag.props.children.join("") : tag.props.children
+          }</${tag.tag}>`
+        : `<${tag.tag} data-sm=""${props}/>`;
+    })
+    .join("");
 }
 
 export const Title: Component<JSX.HTMLAttributes<HTMLTitleElement>> = props =>


### PR DESCRIPTION
This PR addresses an issue in `renderTags` where commas are inserted out of nowhere. This happens because the code assumes that there will only ever be one child node. When it receives multiple text nodes there is an implicit array to string conversion which then inserts the comma.

```tsx
const company = "My cool company"

<Title>blabla - {company}</Title>
```

Old output:

```html
<title>blabla - ,My cool company</title>
```

With this PR:

```html
<title>blabla - My cool company</title>
```

Not if just checking via `Array.isArray` is the idiomatic way to check for singular vs multiple children in solid.