### PR TITLE
feat: add support for solid-js >= 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "jest": "^26.6.3",
         "rimraf": "^3.0.2",
         "solid-jest": "0.1.1",
-        "solid-js": "^1.0.0",
+        "solid-js": "^1.4.2",
         "typescript": "4.3.2"
       },
       "peerDependencies": {
@@ -6636,9 +6636,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mixin-deep": {
@@ -8314,11 +8314,10 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.0.0.tgz",
-      "integrity": "sha512-5huTDVyMqZSjg5Sa4mwl15feK4il1cE68n4weL5NYGC8lX2wiDlcHhBdSB8trKgaJ50Q9/pwtLrQngFaDC+5Tw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.2.tgz",
+      "integrity": "sha512-IU5yKuT8P/n5F5g8j1rTXqxUdPYmoZDk/074TG94AEYf/nyXAeG82BSge4/lLIbCfUcnGUJ6DRdebIjujOAYyg==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -14492,9 +14491,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {
@@ -15839,9 +15838,9 @@
       }
     },
     "solid-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.0.0.tgz",
-      "integrity": "sha512-5huTDVyMqZSjg5Sa4mwl15feK4il1cE68n4weL5NYGC8lX2wiDlcHhBdSB8trKgaJ50Q9/pwtLrQngFaDC+5Tw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.2.tgz",
+      "integrity": "sha512-IU5yKuT8P/n5F5g8j1rTXqxUdPYmoZDk/074TG94AEYf/nyXAeG82BSge4/lLIbCfUcnGUJ6DRdebIjujOAYyg==",
       "dev": true
     },
     "source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "4.3.2"
       },
       "peerDependencies": {
-        "solid-js": "^1.0.0"
+        "solid-js": ">=^1.4.0"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:types": "tsc --project tsconfig.test.json"
   },
   "peerDependencies": {
-    "solid-js": "^1.0.0"
+    "solid-js": ">=^1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",
@@ -41,7 +41,7 @@
     "jest": "^26.6.3",
     "rimraf": "^3.0.2",
     "solid-jest": "0.1.1",
-    "solid-js": "^1.0.0",
+    "solid-js": "^1.4.2",
     "typescript": "4.3.2"
   },
   "jest": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import {
   onCleanup,
   useContext,
   Component,
+  ParentComponent,
   JSX
 } from "solid-js";
 import { isServer, Show, Portal, Dynamic } from "solid-js/web";
@@ -29,7 +30,7 @@ const MetaContext = createContext<MetaContextType>();
 
 const cascadingTags = ["title", "meta"];
 
-const MetaProvider: Component<{ tags?: Array<TagDescription> }> = props => {
+const MetaProvider: ParentComponent<{ tags?: Array<TagDescription> }> = props => {
   const indices = new Map(),
     [tags, setTags] = createSignal<{ [k: string]: (string | null)[] }>({});
 


### PR DESCRIPTION
# Problem

`solid-js` introduced some better typings with the release of v1.4.0. and solid-meta is incompatible with `solid-js@>=1.4.0`. 

This PR fixes the types and makes it compatible with solid@1.4.0