### PR TITLE
improve hydration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -175,7 +175,7 @@ const MetaTag = (tag: string, props: { [k: string]: any }) => {
   const c = useContext(MetaContext);
   if (!c) throw new Error("<MetaProvider /> should be in the tree");
 
-  createHeadTag({
+  useHead({
     tag,
     props,
     id,
@@ -189,7 +189,7 @@ const MetaTag = (tag: string, props: { [k: string]: any }) => {
 
 export { MetaProvider };
 
-function createHeadTag(tagDesc: {
+export function useHead(tagDesc: {
   tag: string;
   props: { [k: string]: any };
   id: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,6 +35,8 @@ const getTagType = (tag: TagDescription) => tag.tag + (tag.name ? `.${tag.name}"
 const MetaProvider: ParentComponent<{ tags?: Array<TagDescription> }> = props => {
   const cascadedTagInstances = new Map();
 
+  // TODO: use one element for all tags of the same type, just swap out
+  // where the props get applied
   function getElement(tag: TagDescription) {
     if (tag.ref) {
       return tag.ref;

--- a/test/hydration_script.ts
+++ b/test/hydration_script.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+
+export function removeScript() {
+  window.$HY = undefined;
+}
+export function hydrationScript() {
+  var e, t;
+  (e =
+    window._$HY ||
+    (window._$HY = {
+      events: [],
+      completed: new WeakSet(),
+      r: {}
+    })),
+    (t = e =>
+      e &&
+      e.hasAttribute &&
+      (e.hasAttribute("data-hk")
+        ? e
+        : t(e.host && e.host instanceof Node ? e.host : e.parentNode))),
+    ["click", "input"].forEach(o =>
+      document.addEventListener(o, o => {
+        let s = (o.composedPath && o.composedPath()[0]) || o.target,
+          a = t(s);
+        a && !e.completed.has(a) && e.events.push([a, o]);
+      })
+    ),
+    (e.init = (t, o) => {
+      e.r[t] = [new Promise((e, t) => (o = e)), o];
+    }),
+    (e.set = (t, o, s) => {
+      (s = e.r[t]) && s[1](o), (e.r[t] = [o]);
+    }),
+    (e.unset = t => {
+      delete e.r[t];
+    }),
+    (e.load = (t, o) => {
+      if ((o = e.r[t])) return o[0];
+    });
+}

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -191,10 +191,10 @@ test("switches between titles", async () => {
     div
   );
 
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  await new Promise(resolve => setTimeout(resolve, 1));
   expect(document.head.innerHTML).toBe(snapshot1);
   setVisible(false);
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  await new Promise(resolve => setTimeout(resolve, 1));
   expect(document.head.innerHTML).toBe(snapshot2);
   dispose();
 });

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -9,7 +9,7 @@ global.queueMicrotask = setImmediate;
 test("renders into document.head portal", () => {
   let div = document.createElement("div");
   const snapshot =
-    '<title>Test title</title><style>body {}</style><link href="index.css"><meta charset="utf-8"><base href="/new_base">';
+    '<title>Test title</title><style>body {}</style><style>div {}</style><link href="index.css"><link href="favicon.ico"><meta charset="utf-8"><base href="/new_base">';
   const dispose = render(
     () => (
       <MetaProvider>
@@ -17,7 +17,9 @@ test("renders into document.head portal", () => {
           Yes render
           <Title>Test title</Title>
           <Style>{`body {}`}</Style>
+          <Style>{`div {}`}</Style>
           <Link href="index.css" />
+          <Link href="favicon.ico" />
           <Meta charset="utf-8" />
           <Base href="/new_base" />
         </div>
@@ -76,7 +78,6 @@ test("hydrates only the last title", () => {
   expect(document.head.innerHTML).toBe(snapshot);
   dispose();
   removeScript();
-  document.head.innerHTML = "";
 });
 
 test("mounts and unmounts title", () => {
@@ -107,7 +108,7 @@ test("mounts and unmounts title", () => {
 test("hydrates and unmounts title", () => {
   hydrationScript();
   let div = document.createElement("div");
-  document.head.innerHTML = `<title data-sm="0-0-0-0">Title 3</title>`;
+  document.head.innerHTML = `<title data-sm="0-0-0-0">Static</title>`;
   const snapshot1 = "<title>Static</title>";
   const snapshot2 = "<title>Dynamic</title>";
   const [visible, setVisible] = createSignal(false);
@@ -129,7 +130,6 @@ test("hydrates and unmounts title", () => {
   setVisible(false);
   expect(document.head.innerHTML).toBe(snapshot1);
   dispose();
-  document.head.innerHTML = "";
   removeScript();
 });
 
@@ -163,7 +163,6 @@ test("switches between titles", async () => {
     div
   );
 
-  await Comp1.preload();
   await new Promise(resolve => setTimeout(resolve, 1000));
   expect(document.head.innerHTML).toBe(snapshot1);
   setVisible(false);

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -1,62 +1,72 @@
 /* @jsxImportSource solid-js */
 import { createSignal } from "solid-js";
 import { render, Show } from "solid-js/web";
-import { MetaProvider, Title, Style, Meta, Link, Base } from '../src';
+import { MetaProvider, Title, Style, Meta, Link, Base } from "../src";
 
 global.queueMicrotask = setImmediate;
 
-test('renders into document.head portal', () => {
+test("renders into document.head portal", () => {
   let div = document.createElement("div");
-  const snapshot = "<title>Test title</title><style>body {}</style><link href=\"index.css\"><meta charset=\"utf-8\"><base href=\"/new_base\">"
-  const dispose = render(() =>
-    <MetaProvider>
-      <div>
-        Yes render
-        <Title>Test title</Title>
-        <Style>{`body {}`}</Style>
-        <Link href="index.css" />
-        <Meta charset="utf-8" />
-        <Base href="/new_base" />
-      </div>
-    </MetaProvider>
-  , div);
+  const snapshot =
+    '<title>Test title</title><style>body {}</style><link href="index.css"><meta charset="utf-8"><base href="/new_base">';
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <div>
+          Yes render
+          <Title>Test title</Title>
+          <Style>{`body {}`}</Style>
+          <Link href="index.css" />
+          <Meta charset="utf-8" />
+          <Base href="/new_base" />
+        </div>
+      </MetaProvider>
+    ),
+    div
+  );
   expect(document.head.innerHTML).toBe(snapshot);
   dispose();
 });
 
-test('renders only the last title', () => {
+test("renders only the last title", () => {
   let div = document.createElement("div");
   const snapshot = "<title>Title 3</title>";
-  const dispose = render(() =>
-    <MetaProvider>
-      <div>
-        <Title>Title 1</Title>
-      </div>
-      <div>
-        <Title>Title 2</Title>
-      </div>
-      <div>
-        <Title>Title 3</Title>
-      </div>
-    </MetaProvider>
-  , div);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <div>
+          <Title>Title 1</Title>
+        </div>
+        <div>
+          <Title>Title 2</Title>
+        </div>
+        <div>
+          <Title>Title 3</Title>
+        </div>
+      </MetaProvider>
+    ),
+    div
+  );
   expect(document.head.innerHTML).toBe(snapshot);
   dispose();
 });
 
-test('mounts and unmounts title', () => {
+test("mounts and unmounts title", () => {
   let div = document.createElement("div");
   const snapshot1 = "<title>Static</title>";
   const snapshot2 = "<title>Dynamic</title>";
-  const [visible, setVisible] = createSignal(false)
-  const dispose = render(() =>
-    <MetaProvider>
-      <Title>Static</Title>
-      <Show when={visible()}>
-        <Title>Dynamic</Title>
-      </Show>
-    </MetaProvider>
-  , div);
+  const [visible, setVisible] = createSignal(false);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <Title>Static</Title>
+        <Show when={visible()}>
+          <Title>Dynamic</Title>
+        </Show>
+      </MetaProvider>
+    ),
+    div
+  );
 
   expect(document.head.innerHTML).toBe(snapshot1);
   setVisible(true);
@@ -66,26 +76,29 @@ test('mounts and unmounts title', () => {
   dispose();
 });
 
-test('switches between titles', () => {
+test("switches between titles", () => {
   let div = document.createElement("div");
   const snapshot1 = "<title>Title 1</title>";
   const snapshot2 = "<title>Title 2</title>";
-  const [visible, setVisible] = createSignal(true)
-  const dispose = render(() =>
-    <MetaProvider>
-      <Title>Static</Title>
-      <Show when={visible()} fallback={<Title>Title 2</Title>}>
-        <Title>Title 1</Title>
-      </Show>
-    </MetaProvider>
-  , div);
+  const [visible, setVisible] = createSignal(true);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <Title>Static</Title>
+        <Show when={visible()} fallback={<Title>Title 2</Title>}>
+          <Title>Title 1</Title>
+        </Show>
+      </MetaProvider>
+    ),
+    div
+  );
   expect(document.head.innerHTML).toBe(snapshot1);
   setVisible(false);
   expect(document.head.innerHTML).toBe(snapshot2);
   dispose();
 });
 
-test('renders only the last meta with the same name', () => {
+test("renders only the last meta with the same name", () => {
   let div = document.createElement("div");
 
   /* Something weird in this env
@@ -94,31 +107,34 @@ test('renders only the last meta with the same name', () => {
   const snapshot3 = "<meta>Dynamic 2</meta><meta name=\"name1\">Dynamic 1</meta>";
   */
 
-  const snapshot1 = "<meta><meta name=\"name1\">";
-  const snapshot2 = "<meta><meta name=\"name1\">";
-  const snapshot3 = "<meta name=\"name1\"><meta>";
-  const snapshot4 = "<meta name=\"name1\"><meta>";
+  const snapshot1 = '<meta><meta name="name1">';
+  const snapshot2 = '<meta><meta name="name1">';
+  const snapshot3 = '<meta name="name1"><meta>';
+  const snapshot4 = '<meta name="name1"><meta>';
 
   const [visible1, setVisible1] = createSignal(false);
   const [visible2, setVisible2] = createSignal(false);
-  const dispose = render(() =>
-    <MetaProvider>
-      <Meta>Static 1</Meta>
-      <Meta name="name1">Static 2</Meta>
-      <Show when={visible1()}>
-        <Meta name="name1">Dynamic 1</Meta>
-      </Show>
-      <Show when={visible2()}>
-        <Meta>Dynamic 2</Meta>
-      </Show>
-    </MetaProvider>
-  , div);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <Meta>Static 1</Meta>
+        <Meta name="name1">Static 2</Meta>
+        <Show when={visible1()}>
+          <Meta name="name1">Dynamic 1</Meta>
+        </Show>
+        <Show when={visible2()}>
+          <Meta>Dynamic 2</Meta>
+        </Show>
+      </MetaProvider>
+    ),
+    div
+  );
   expect(document.head.innerHTML).toBe(snapshot1);
   // mount first
   setVisible1(true);
   expect(document.head.innerHTML).toBe(snapshot2);
   // mount second
-  setVisible2(true)
+  setVisible2(true);
   expect(document.head.innerHTML).toBe(snapshot3);
   // unmount second
   setVisible2(false);
@@ -129,25 +145,28 @@ test('renders only the last meta with the same name', () => {
   dispose();
 });
 
-test('renders only last meta with the same property', () => {
+test("renders only last meta with the same property", () => {
   let div = document.createElement("div");
   // something weird with meta tag stringification in this env
-  const snapshot = "<meta property=\"name1\"><meta name=\"name2\"><meta property=\"name3\">";
-  const dispose = render(() =>
-    <MetaProvider>
-      <Meta property="name1">Meta 1</Meta>
-      <Meta property="name1">Meta 2</Meta>
-      <Meta property="name2">Meta 3</Meta>
-      <Meta name="name2">Meta 4</Meta>
-      <Meta name="name3">Meta 5</Meta>
-      <Meta property="name3">Meta 6</Meta>
-    </MetaProvider>
-  , div);
+  const snapshot = '<meta property="name1"><meta name="name2"><meta property="name3">';
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <Meta property="name1">Meta 1</Meta>
+        <Meta property="name1">Meta 2</Meta>
+        <Meta property="name2">Meta 3</Meta>
+        <Meta name="name2">Meta 4</Meta>
+        <Meta name="name3">Meta 5</Meta>
+        <Meta property="name3">Meta 6</Meta>
+      </MetaProvider>
+    ),
+    div
+  );
   expect(document.head.innerHTML).toBe(snapshot);
   dispose();
 });
 
-test('throws error if head tag is rendered without MetaProvider', () => {
+test("throws error if head tag is rendered without MetaProvider", () => {
   expect(() => {
     let div = document.createElement("div");
     render(() => <Style>{`body {}`}</Style>, div);

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -54,6 +54,34 @@ test("renders only the last title", () => {
   dispose();
 });
 
+test("unmount middle child, should show only the last title", () => {
+  let div = document.createElement("div");
+  const snapshot = "<title>Title 3</title>";
+  const [visible, setVisible] = createSignal(true);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <div>
+          <Title>Title 1</Title>
+        </div>
+        <Show when={visible()}>
+          <div>
+            <Title>Title 2</Title>
+          </div>
+        </Show>
+        <div>
+          <Title>Title 3</Title>
+        </div>
+      </MetaProvider>
+    ),
+    div
+  );
+  expect(document.head.innerHTML).toBe(snapshot);
+  setVisible(false);
+  expect(document.head.innerHTML).toBe(snapshot);
+  dispose();
+});
+
 test("hydrates only the last title", () => {
   hydrationScript();
   let div = document.createElement("div");


### PR DESCRIPTION
dont remove old tags with the same data-sm ids as the client one (generated using `createUniqueId()`).. we manually populate/assign/delete from document.head in a render effect

Also added a Stylesheet export.. for goodness