### PR TITLE
🐛 Make sure, that singleton is attached

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -124,7 +124,7 @@ function initClientProvider() {
         if (element.parentNode != document.head) {
           document.head.appendChild(element);
         }
-        if (lastVisited && lastVisited.ref) {
+        if (lastVisited && lastVisited.ref && lastVisited.ref.parentNode) {
           document.head!.removeChild(lastVisited.ref);
         }
 


### PR DESCRIPTION
`removeChild` fails loudly if it tries to detach something, which does
not have parent, so we always need to check this beforehand.

All of the other calls to removeChild() have similar checks already

Close #38
