### PR TITLE
Fix removing one <title> renders all previous <title>s

### DIFF
--- a/.changeset/wide-clubs-serve.md
+++ b/.changeset/wide-clubs-serve.md
@@ -1,0 +1,5 @@
+---
+"@solidjs/meta": patch
+---
+
+Fix removing one <title> renders all previous <title>s

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,6 +155,7 @@ function initClientProvider() {
             for (let i = index - 1; i >= 0; i--) {
               if (t[i] != null) {
                 document.head.appendChild(t[i].ref);
+                break;
               }
             }
           }

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -247,7 +247,7 @@ test("renders only the last meta with the same name", () => {
   const snapshot1 = '<meta><meta name="name1">';
   const snapshot2 = '<meta><meta name="name1">';
   const snapshot3 = '<meta name="name1"><meta>';
-  
+
   const [visible1, setVisible1] = createSignal(false);
   const [visible2, setVisible2] = createSignal(false);
   const dispose = render(
@@ -308,16 +308,8 @@ test("renders both meta with the same name/property but different other attribut
   const dispose = render(
     () => (
       <MetaProvider>
-        <Meta
-          name="theme-color"
-          media="(prefers-color-scheme: light)"
-          content="#fff"
-        />
-        <Meta
-          name="theme-color"
-          media="(prefers-color-scheme: dark)"
-          content="#000"
-        />
+        <Meta name="theme-color" media="(prefers-color-scheme: light)" content="#fff" />
+        <Meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000" />
       </MetaProvider>
     ),
     div
@@ -336,7 +328,7 @@ test("throws error if head tag is rendered without MetaProvider", () => {
 test("doesn't create any effect on removal", () => {
   let div = document.createElement("div");
 
-  const [ show, setShow ] = createSignal(true);
+  const [show, setShow] = createSignal(true);
   const showAndTest = () => {
     expect(getOwner()?.owner).toBeTruthy();
     return show();
@@ -346,7 +338,9 @@ test("doesn't create any effect on removal", () => {
     () => (
       <MetaProvider>
         <Show when={show()}>
-          <Title>Something {showAndTest()} that forces the Solid compiler to create a memo here</Title>
+          <Title>
+            Something {showAndTest()} that forces the Solid compiler to create a memo here
+          </Title>
         </Show>
       </MetaProvider>
     ),
@@ -359,7 +353,8 @@ test("doesn't create any effect on removal", () => {
 
 test("Escaping the title tag", () => {
   let div = document.createElement("div");
-  const snapshot = '<title>Hello&lt;/title&gt;&lt;script&gt;alert("inject");&lt;/script&gt;&lt;title&gt; World</title>';
+  const snapshot =
+    '<title>Hello&lt;/title&gt;&lt;script&gt;alert("inject");&lt;/script&gt;&lt;title&gt; World</title>';
   const dispose = render(
     () => (
       <MetaProvider>

--- a/test/index.spec.tsx
+++ b/test/index.spec.tsx
@@ -89,6 +89,35 @@ test("unmount middle child, should show only the last title", () => {
   dispose();
 });
 
+test("unmount last child, should show only the second last title", () => {
+  let div = document.createElement("div");
+  const snapshot1 = "<title>Title 3</title>";
+  const snapshot2 = "<title>Title 2</title>";
+  const [visible, setVisible] = createSignal(true);
+  const dispose = render(
+    () => (
+      <MetaProvider>
+        <div>
+          <Title>Title 1</Title>
+        </div>
+        <div>
+          <Title>Title 2</Title>
+        </div>
+        <Show when={visible()}>
+          <div>
+            <Title>Title 3</Title>
+          </div>
+        </Show>
+      </MetaProvider>
+    ),
+    div
+  );
+  expect(document.head.innerHTML).toBe(snapshot1);
+  setVisible(false);
+  expect(document.head.innerHTML).toBe(snapshot2);
+  dispose();
+});
+
 test("hydrates only the last title", () => {
   hydrationScript();
   let div = document.createElement("div");


### PR DESCRIPTION
`removeTag` missing a `break` causing all previous `<title>` tags to be rendered.

Repro playground: https://playground.solidjs.com/anonymous/4fa1f8e7-fcb6-4f6c-a521-daf6207fc779 (looks like `@solidjs/meta` doesn't work well with HMR, so I need to refresh the preview every time I edited the source code)

For whatever reason, I need to add `babel-jest` package to root `package.json` for tests to run. I installed with `pnpm@8.15.9` but it still dramatically changed the lockfile, however, it didn't add any new packages.

Output from `pnpm test` after cloning and `pnpm i`:

```
~/solidjs/solid-meta main 3s
❯ pnpm test

> @solidjs/meta@0.29.4 test /home/solidjs/solid-meta
> jest && npm run test:types

: ● Validation Error:

  Module babel-jest in the transform option was not found.
         <rootDir> is: /home/solidjs/solid-meta

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html

 ELIFECYCLE  Test failed. See above for more details.
```